### PR TITLE
Edit the message the bot sends in `ping.ts`

### DIFF
--- a/src/message-commands/ping.ts
+++ b/src/message-commands/ping.ts
@@ -3,13 +3,13 @@ import { MessageCommand } from "@lilybird/handlers";
 export default {
   name: "ping",
   run: async (message) => {
-    await message.reply({
+    const newMessage = await message.reply({
       content: "🏓...",
     });
 
     const { ws, rest } = await message.client.ping();
 
-    await message.edit({
+    await newMessage.edit({
       content: `🏓 WebSocket: \`${ws}ms\` | Rest: \`${rest}ms\``,
     });
   },


### PR DESCRIPTION
In `message-commands/ping.ts`, the code attempts to edit the message the author sent, resulting in an error on line 12.
This pr fixes that bug