### PR TITLE
patch: immediate remedy to ping bypass

### DIFF
--- a/src/commands/tag.tsx
+++ b/src/commands/tag.tsx
@@ -27,7 +27,7 @@ export default {
     const tag = searchTag(interaction.channel, query, false);
     if (!tag) {
       return interaction.reply({
-        content: `\`❌\` Could not find a tag \`${query}\``,
+        content: `\`❌\` Could not find a tag \`${query.replace(/(@&?)(here|everyone|\d+)/, '$1\u200b$2')}\``,
         ephemeral: true,
       });
     }


### PR DESCRIPTION
`lilybird` currently lacks the ability to use `allowed_mentions` in the response body (https://github.com/Didas-git/lilybird/issues/25).
https://lilybird.didas.dev/modules/transformers/documentation/interfaces/interactionreplyoptions/

![image](https://github.com/xHyroM/bun-discord-bot/assets/8607699/30369c29-83dd-4bfb-b4a0-827403a374c9)

_Only escapes for no tag match. This may have already been dealt with (or not the desired fix)._